### PR TITLE
Update error output

### DIFF
--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.4</version>
+  <version>1.2.5</version>
   <name>cumulus-message-adapter</name>
   <url>https://github.com/cumulus-nasa/cumulus-message-adapter-java</url>
   <licenses>

--- a/message_parser/src/test/java/cumulus_sled/message_parser/MessageParserTest.java
+++ b/message_parser/src/test/java/cumulus_sled/message_parser/MessageParserTest.java
@@ -127,7 +127,7 @@ public class MessageParserTest
     {
         MessageParser parser = new MessageParser(new TestMessageAdapter());
         String inputJson = "{\"workflow_config\":{\"Example\":{\"bar\":\"baz\"}}}";
-        String expectedOutput = "{\"payload\":null,\"exception\":\"workflow exception\"}";
+        String expectedOutput = "{\"workflow_config\":{\"Example\":{\"bar\":\"baz\"}},\"payload\":null,\"exception\":\"workflow exception\"}";
 
         try
         {


### PR DESCRIPTION
While working on [Cumulus-726](https://bugs.earthdata.nasa.gov/browse/CUMULUS-726) I noticed there was an inconsistency between how we handle `WorkflowError`s across the 3 cumulus-message-adapter libraries.

When the js and python CMA libraries catch an error and it is a `WorkflowError` (or a `WorkflowException` in the case of the java library), they return the original input to the lambda, with the `payload` key overwritten as `null` and the `exception` overwritten as the exception.

See:
* https://github.com/nasa/cumulus-message-adapter-js/blob/master/index.js#L174-L176
* https://github.com/nasa/cumulus-message-adapter-python/blob/master/run_cumulus_task.py#L39-L43

Testing:
- [x] Updated unit test
- [x] Deployed package as dependency of the `CnmResponse` Task in a Cumulus workflow. Updated `CnmResponse` to throw a `WorkflowException` and verified the output of the `CnmResponse` task was what I expected: the error was caught by the cumulus message adapter java library and the output object included `payload: null` and `exception: {<Exception Object>}`

