### PR TITLE
CUMULUS-686: store task metadata

### DIFF
--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.6</version>
+  <version>1.2.7</version>
   <name>cumulus-message-adapter</name>
   <url>https://github.com/cumulus-nasa/cumulus-message-adapter-java</url>
   <licenses>

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/IMessageAdapter.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/IMessageAdapter.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 public interface IMessageAdapter
 {
     String CallMessageAdapterFunction(String messageAdapterFunction, String inputJson) throws MessageAdapterException;
-    String LoadRemoteEvent(String eventJson, SchemaLocations schemaLocations) throws MessageAdapterException;
+    String LoadAndUpdateRemoteEvent(String eventJson, Context context, SchemaLocations schemaLocations) throws MessageAdapterException;
     String LoadNestedEvent(String eventJson, Context context, SchemaLocations schemaLocations) throws MessageAdapterException;
     String CreateNextEvent(String remoteEventJson, String nestedEventJson, String taskJson, SchemaLocations schemaLocations) throws MessageAdapterException;
 }

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
@@ -19,7 +19,7 @@ public class MessageAdapter implements IMessageAdapter
     /**
      * Call to message adapter zip to execute a message adapter function. Pass args through the process input
      * and read return result from process output.
-     * @param messageAdapterFunction - 'loadRemoteEvent', 'loadNestedEvent', or 'createNextEvent'
+     * @param messageAdapterFunction - 'loadAndUpdateRemoteEvent', 'loadNestedEvent', or 'createNextEvent'
      * @param inputJson - argument to message adapter function. Json that contains all of the params.
      * @return the return from the message adapter function
      */
@@ -92,7 +92,7 @@ public class MessageAdapter implements IMessageAdapter
      * @param eventJson - Json passed from lambda
      * @param context - AWS Lambda context
      * @param schemaLocations - locations of JSON schemas
-     * @return result of 'loadRemoteEvent'
+     * @return result of 'loadAndUpdateRemoteEvent'
      */
     public String LoadAndUpdateRemoteEvent(String eventJson, Context context, SchemaLocations schemaLocations)
         throws MessageAdapterException
@@ -110,7 +110,7 @@ public class MessageAdapter implements IMessageAdapter
     /**
      * Format the arguments and call the 'loadNestedEvent' message adapter function
      * 
-     * @param eventJson - Json from loadRemoteEvent
+     * @param eventJson - Json from loadAndUpdateRemoteEvent
      * @param context - AWS Lambda context
      * @param schemaLocations - locations of JSON schemas
      * @return result of 'loadNestedEvent'
@@ -130,7 +130,7 @@ public class MessageAdapter implements IMessageAdapter
     /**
      * Format the arguments and call the 'createNextEvent' message adapter function
      * 
-     * @param remoteEventJson - Json result from 'loadRemoteEvent'
+     * @param remoteEventJson - Json result from 'loadAndUpdateRemoteEvent'
      * @param nestedEventJson - Json result from 'loadNestedEvent'
      * @param taskJson - result from calling the task
      * @param schemaLocations - locations of JSON schemas

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
@@ -87,22 +87,24 @@ public class MessageAdapter implements IMessageAdapter
     }
 
     /**
-     * Format the arguments and call the 'loadRemoteEvent' message adapter function
+     * Format the arguments and call the 'loadAndUpdateRemoteEvent' message adapter function
      * 
      * @param eventJson - Json passed from lambda
+     * @param context - AWS Lambda context
      * @param schemaLocations - locations of JSON schemas
      * @return result of 'loadRemoteEvent'
      */
-    public String LoadRemoteEvent(String eventJson, SchemaLocations schemaLocations)
+    public String LoadAndUpdateRemoteEvent(String eventJson, Context context, SchemaLocations schemaLocations)
         throws MessageAdapterException
     {
         Gson gson = new Gson();
 
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("event", gson.fromJson(eventJson, Map.class));
+        map.put("context", context);
         map.put("schemas", schemaLocations);
 
-        return CallMessageAdapterFunction("loadRemoteEvent", gson.toJson(map));
+        return CallMessageAdapterFunction("loadAndUpdateRemoteEvent", gson.toJson(map));
     }
 
     /**

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageParser.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageParser.java
@@ -60,7 +60,7 @@ public class MessageParser implements IMessageParser
                 return task.PerformFunction(input, context);
             }
 
-            String remoteEvent = _messageAdapter.LoadRemoteEvent(input, schemaLocations);
+            String remoteEvent = _messageAdapter.LoadAndUpdateRemoteEvent(input, context, schemaLocations);
 
             // If we pulled a remote event, set up the executions again
             if(remoteEvent != input)

--- a/message_parser/src/test/java/cumulus_sled/message_parser/MessageParserTest.java
+++ b/message_parser/src/test/java/cumulus_sled/message_parser/MessageParserTest.java
@@ -68,7 +68,7 @@ public class MessageParserTest
         
         try
         {
-            assertEquals(expectedOutput, messageAdapter.LoadAndUpdateRemoteEvent(inputJson, null));
+            assertEquals(expectedOutput, messageAdapter.LoadAndUpdateRemoteEvent(inputJson, null, null));
         }
         catch(MessageAdapterException e)
         {

--- a/message_parser/src/test/java/cumulus_sled/message_parser/MessageParserTest.java
+++ b/message_parser/src/test/java/cumulus_sled/message_parser/MessageParserTest.java
@@ -57,10 +57,10 @@ public class MessageParserTest
     }
 
     /**
-     * Test that LoadRemoteEvent converts input to JSON correctly
+     * Test that LoadAndUpdateRemoteEvent converts input to JSON correctly
      */
     @Test
-    public void testLoadRemoteEvent()
+    public void testLoadAndUpdateRemoteEvent()
     {
         TestMessageAdapter messageAdapter = new TestMessageAdapter();
         String inputJson = "{\"workflow_config\":{\"Example\":{\"bar\":\"baz\"}},\"cumulus_meta\":{\"task\":\"Example\",\"message_source\":\"local\",\"id\":\"id-1234\"},\"meta\":{\"foo\":\"bar\"},\"payload\":{\"anykey\":\"anyvalue\"}}";
@@ -68,7 +68,7 @@ public class MessageParserTest
         
         try
         {
-            assertEquals(expectedOutput, messageAdapter.LoadRemoteEvent(inputJson, null));
+            assertEquals(expectedOutput, messageAdapter.LoadAndUpdateRemoteEvent(inputJson, null));
         }
         catch(MessageAdapterException e)
         {

--- a/message_parser/src/test/java/cumulus_sled/message_parser/TestEventMessageAdapter.java
+++ b/message_parser/src/test/java/cumulus_sled/message_parser/TestEventMessageAdapter.java
@@ -13,7 +13,7 @@ public class TestEventMessageAdapter extends MessageAdapter
     /**
      * Return the event portion of the input JSON for testing purposes
      * 
-     * @param messageAdapterFunction - 'loadRemoteEvent', 'loadNestedEvent', or 'createNextEvent'
+     * @param messageAdapterFunction - 'loadAndUpdateRemoteEvent', 'loadNestedEvent', or 'createNextEvent'
      * @param inputJson - argument to message adapter function. Json that contains all of the params.
      * @return inputJson to test JSON conversions
      */

--- a/message_parser/src/test/java/cumulus_sled/message_parser/TestMessageAdapter.java
+++ b/message_parser/src/test/java/cumulus_sled/message_parser/TestMessageAdapter.java
@@ -10,7 +10,7 @@ public class TestMessageAdapter extends MessageAdapter
     /**
      * Return input JSON for testing purposes
      * 
-     * @param messageAdapterFunction - 'loadRemoteEvent', 'loadNestedEvent', or 'createNextEvent'
+     * @param messageAdapterFunction - 'loadAndUpdateRemoteEvent', 'loadNestedEvent', or 'createNextEvent'
      * @param inputJson - argument to message adapter function. Json that contains all of the params.
      * @return inputJson to test JSON conversions
      */


### PR DESCRIPTION
Call updated methods in the `cumulus-message-adapter` python library to update the remote event with task metadata.