### PR TITLE
Update aws-lambda-java-log4j2

### DIFF
--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.0.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
See https://aws.amazon.com/security/security-bulletins/AWS-2021-005/

`Customers using the aws-lambda-java-log4j2 (https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-log4j2/) library in their functions will need to update to version 1.3.0 and redeploy.`