### PR TITLE
Update vulnerable libs & bump version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,11 @@ jobs:
       # run tests!
       - run: mvn -f message_parser/pom.xml integration-test
 
+      - run:
+          name: Publish release
+          command: |
+            GITHUB_TOKEN=${GITHUB_TOKEN} sh bin/release.sh
+
   deploy:
     docker:
       # specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Publish release
           command: |
-            GITHUB_TOKEN=${GITHUB_TOKEN} sh bin/release.sh
+            GITHUB_TOKEN=${GITHUB_TOKEN} sh scripts/release.sh
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,8 @@ workflows:
   build_and_deploy:
     jobs:
       - build:
-        context:
-          - cumulus-packages
+          context:
+            - cumulus-packages
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,14 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+      - build:
+          context:
+            - cumulus-packages
       - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
+          context:
+            - cumulus-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,14 +62,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build:
-          context:
-            - cumulus-packages
+      - build
       - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
-          context:
-            - cumulus-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,6 @@ jobs:
       # run tests!
       - run: mvn -f message_parser/pom.xml integration-test
 
-      - run:
-          name: Publish release
-          command: |
-            GITHUB_TOKEN=${GITHUB_TOKEN} sh scripts/release.sh
-
   deploy:
     docker:
       # specify the version you desire here
@@ -57,6 +52,11 @@ jobs:
 
       # publish to clojars
       - run: mvn -s .circleci/.circleci.settings.xml -f message_parser/pom.xml deploy
+
+      - run:
+          name: Publish release
+          command: |
+            GITHUB_TOKEN=${GITHUB_TOKEN} sh scripts/release.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -59,7 +59,7 @@ jobs:
       - run: mvn -s .circleci/.circleci.settings.xml -f message_parser/pom.xml deploy
 
 workflows:
-  version: 2
+  version: 2.1
   build_and_deploy:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
-version: 2.1
+version: 2
 jobs:
   build:
     docker:
@@ -59,10 +59,10 @@ jobs:
       - run: mvn -s .circleci/.circleci.settings.xml -f message_parser/pom.xml deploy
 
 workflows:
-  version: 2.1
+  version: 2
   build_and_deploy:
     jobs:
-      - build
+      - build:
         context:
           - cumulus-packages
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,13 @@ workflows:
   build_and_deploy:
     jobs:
       - build
+        context:
+          - cumulus-packages
       - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
+          context:
+            - cumulus-packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [v1.3.3] - 2021-12-13
+
+### Fixed
+
+- Updated `aws-lambda-java-log4j2` to `1.3.0` and `org.apache.logging.log4j` to `2.15.0` to address [critical security vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228)
+- Updated `com.google.code.gson` to `2.8.9` to address security vulnerabilities
+
 ## [v1.3.2] - 2020-11-19
 
 ### Fixed

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -55,11 +55,6 @@
       <artifactId>log4j-core</artifactId>
       <version>2.15.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
-    </dependency>
   </dependencies>
   <build>
   <plugins>

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.2</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.2</version>
+  <version>1.3.3</version>
   <name>cumulus-message-adapter</name>
   <url>https://github.com/cumulus-nasa/cumulus-message-adapter-java</url>
   <licenses>

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.0.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/AdapterUtilities.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/AdapterUtilities.java
@@ -58,6 +58,10 @@ public class AdapterUtilities {
         conn.setRequestProperty("Accept", "application/json");
         conn.setRequestProperty("User-Agent", "@cumulus/deployment");
 
+        if (System.getenv("GITHUB_TOKEN") != null) {
+            conn.setRequestProperty("Authorization", "token " + System.getenv("GITHUB_TOKEN"));
+        }
+
         if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
             throw new RuntimeException("Request Failed. HTTP Error Code: " + conn.getResponseCode());
         }
@@ -82,11 +86,7 @@ public class AdapterUtilities {
      * @throws IOException
      */
     private static String fetchLatestMessageAdapterRelease() throws IOException {
-        String url = (System.getenv("GITHUB_TOKEN") != null)
-                ? CMA_GITHUB_PATH_URL + "?access_token=" + System.getenv("GITHUB_TOKEN")
-                : CMA_GITHUB_PATH_URL;
-
-        String jsonString = getJsonResponse(url);
+        String jsonString = getJsonResponse(CMA_GITHUB_PATH_URL);
         Map<String, Object> map = JsonUtils.toMap(jsonString);
         return (String) map.get("tag_name");
     }

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageParserTest.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageParserTest.java
@@ -4,9 +4,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 
-import cumulus_message_adapter.message_parser.MessageAdapterException;
-import cumulus_message_adapter.message_parser.MessageParser;
-
 import org.junit.Test;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,30 +5,29 @@ VERSION_NUMBER=$(cd message_parser && mvn help:evaluate -Dexpression=project.ver
 export VERSION_NUMBER
 export VERSION_TAG="v$VERSION_NUMBER"
 
-echo "$VERSION_TAG"
-# export LATEST_TAG=$(curl -H \
-#   "Authorization: token $GITHUB_TOKEN" \
-#   https://api.github.com/repos/nasa/cumulus-message-adapter-java/tags | jq --raw-output '.[0].name')
+export LATEST_TAG=$(curl -H \
+  "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/nasa/cumulus-message-adapter-java/tags | jq --raw-output '.[0].name')
 
-# if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then
-#   echo "tag does not exist for version $VERSION_TAG, creating tag"
+if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then
+  echo "tag does not exist for version $VERSION_TAG, creating tag"
 
-#   # create git tag
-#   git tag -a "$VERSION_TAG" -m "$VERSION_TAG" || echo "$VERSION_TAG already exists"
-#   git push origin "$VERSION_TAG"
-# fi
+  # create git tag
+  # git tag -a "$VERSION_TAG" -m "$VERSION_TAG" || echo "$VERSION_TAG already exists"
+  # git push origin "$VERSION_TAG"
+fi
 
-# export RELEASE_URL=$(curl -H \
-#   "Authorization: token $GITHUB_TOKEN" \
-#   https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases/tags/$VERSION_TAG | jq --raw-output '.url // ""')
+export RELEASE_URL=$(curl -H \
+  "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases/tags/$VERSION_TAG | jq --raw-output '.url // ""')
 
-# if [ -z "$RELEASE_URL" ]; then
-#   echo "release does not exist"
+if [ -z "$RELEASE_URL" ]; then
+  echo "release does not exist"
 
-#   curl -H \
-#     "Authorization: token $GITHUB_TOKEN" \
-#     -d "{\"tag_name\": \"$VERSION_TAG\", \"name\": \"$VERSION_TAG\", \"body\": \"Release $VERSION_TAG\" }"\
-#     -H "Content-Type: application/json"\
-#     -X POST \
-#     https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases
-# fi
+  # curl -H \
+  #   "Authorization: token $GITHUB_TOKEN" \
+  #   -d "{\"tag_name\": \"$VERSION_TAG\", \"name\": \"$VERSION_TAG\", \"body\": \"Release $VERSION_TAG\" }"\
+  #   -H "Content-Type: application/json"\
+  #   -X POST \
+  #   https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,8 +14,8 @@ if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then
   echo "tag does not exist for version $VERSION_TAG, creating tag"
 
   # create git tag
-  # git tag -a "$VERSION_TAG" -m "$VERSION_TAG" || echo "$VERSION_TAG already exists"
-  # git push origin "$VERSION_TAG"
+  git tag -a "$VERSION_TAG" -m "$VERSION_TAG" || echo "$VERSION_TAG already exists"
+  git push origin "$VERSION_TAG"
 fi
 
 RELEASE_URL=$(curl -H \
@@ -26,10 +26,10 @@ export RELEASE_URL
 if [ -z "$RELEASE_URL" ]; then
   echo "release does not exist"
 
-  # curl -H \
-  #   "Authorization: token $GITHUB_TOKEN" \
-  #   -d "{\"tag_name\": \"$VERSION_TAG\", \"name\": \"$VERSION_TAG\", \"body\": \"Release $VERSION_TAG\" }"\
-  #   -H "Content-Type: application/json"\
-  #   -X POST \
-  #   https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases
+  curl -H \
+    "Authorization: token $GITHUB_TOKEN" \
+    -d "{\"tag_name\": \"$VERSION_TAG\", \"name\": \"$VERSION_TAG\", \"body\": \"Release $VERSION_TAG\" }"\
+    -H "Content-Type: application/json"\
+    -X POST \
+    https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,9 +5,10 @@ VERSION_NUMBER=$(cd message_parser && mvn help:evaluate -Dexpression=project.ver
 export VERSION_NUMBER
 export VERSION_TAG="v$VERSION_NUMBER"
 
-export LATEST_TAG=$(curl -H \
+LATEST_TAG=$(curl -H \
   "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/nasa/cumulus-message-adapter-java/tags | jq --raw-output '.[0].name')
+export LATEST_TAG
 
 if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then
   echo "tag does not exist for version $VERSION_TAG, creating tag"
@@ -17,9 +18,10 @@ if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then
   # git push origin "$VERSION_TAG"
 fi
 
-export RELEASE_URL=$(curl -H \
+RELEASE_URL=$(curl -H \
   "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases/tags/$VERSION_TAG | jq --raw-output '.url // ""')
+export RELEASE_URL
 
 if [ -z "$RELEASE_URL" ]; then
   echo "release does not exist"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -ex
+VERSION_NUMBER=$(cd message_parser && mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+export VERSION_NUMBER
+export VERSION_TAG="v$VERSION_NUMBER"
+
+echo "$VERSION_TAG"
+# export LATEST_TAG=$(curl -H \
+#   "Authorization: token $GITHUB_TOKEN" \
+#   https://api.github.com/repos/nasa/cumulus-message-adapter-java/tags | jq --raw-output '.[0].name')
+
+# if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then
+#   echo "tag does not exist for version $VERSION_TAG, creating tag"
+
+#   # create git tag
+#   git tag -a "$VERSION_TAG" -m "$VERSION_TAG" || echo "$VERSION_TAG already exists"
+#   git push origin "$VERSION_TAG"
+# fi
+
+# export RELEASE_URL=$(curl -H \
+#   "Authorization: token $GITHUB_TOKEN" \
+#   https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases/tags/$VERSION_TAG | jq --raw-output '.url // ""')
+
+# if [ -z "$RELEASE_URL" ]; then
+#   echo "release does not exist"
+
+#   curl -H \
+#     "Authorization: token $GITHUB_TOKEN" \
+#     -d "{\"tag_name\": \"$VERSION_TAG\", \"name\": \"$VERSION_TAG\", \"body\": \"Release $VERSION_TAG\" }"\
+#     -H "Content-Type: application/json"\
+#     -X POST \
+#     https://api.github.com/repos/nasa/cumulus-message-adapter-java/releases
+# fi

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.2</version>
+      <version>2.8.9</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
- Update vulnerable log4j dependencies (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) and others
- Update lib version