### PR TITLE
Update aws lambda log4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [v1.3.7] - 2021-12-20
+
+### Added
+
+- Added `log4j-api` version `1.7.0`
+
+### Fixed
+
+- Updated `aws-lambda-java-log4j2` to `1.5.0` to address [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)
+
 ## [v1.3.6] - 2021-12-20
 
 ### Fixed

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.6</version>
+  <version>1.3.7</version>
   <name>cumulus-message-adapter</name>
   <url>https://github.com/cumulus-nasa/cumulus-message-adapter-java</url>
   <licenses>

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -48,11 +48,16 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>2.17.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
       <version>2.17.0</version>
     </dependency>
   </dependencies>

--- a/message_parser/src/main/resources/log4j2.xml
+++ b/message_parser/src/main/resources/log4j2.xml
@@ -1,8 +1,9 @@
-<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
   <Appenders>
     <Lambda name="Lambda">
       <PatternLayout>
-          <pattern>%msg%n</pattern>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
       </PatternLayout>
     </Lambda>
   </Appenders>


### PR DESCRIPTION
Needed to update `aws-lambda-java-log4j2` to `1.5.0` to address vulnerability as well.

Updated configuration and versions to match AWS guidance:

https://github.com/aws/aws-lambda-java-libs/tree/master/aws-lambda-java-log4j2