### PR TITLE
CUMULUS-3182:Update AdapterLogger.InitializeLogger to be public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 This version of the CMA java client works with cumulus-message-adapter
 [v2.0.2](https://github.com/nasa/cumulus-message-adapter/releases/tag/v2.0.2) or earlier,
-and it's built with JDK 1.8 and Gradle 8.
+and it's built with JDK 1.8.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - **CUMULUS-3182**
   - Updated `AdapterLogger.InitializeLogger` method to be public
-  - Updated example Cumulus task to initialize logger, and build with Gradle 8
+  - Updated example Cumulus task to initialize logger, build with Gradle 8 and
+  updated com.amazonaws libraries
 
 ## [v1.3.9] - 2022-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [v1.3.10] - 2023-08-04
+## [v1.3.10] - 2023-08-07
+
+### Note
+
+This version of the CMA java client works with cumulus-message-adapter
+[v2.0.2](https://github.com/nasa/cumulus-message-adapter/releases/tag/v2.0.2) or earlier,
+and it's built with JDK 1.8 and Gradle 8.
 
 ### Changed
 
 - **CUMULUS-3182**
   - Updated `AdapterLogger.InitializeLogger` method to be public
-  - Updated example Cumulus task to initialize logger, build with Gradle 8 and
-  updated com.amazonaws libraries
+  - Updated example Cumulus task to initialize logger, build with Gradle 8
+  - Updated com.amazonaws libraries to address security vulnerability
 
 ## [v1.3.9] - 2022-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [v1.3.10] - 2023-08-04
+
+### Changed
+
+- **CUMULUS-3182**
+  - Updated `AdapterLogger.InitializeLogger` method to be public
+  - Updated example Cumulus task to initialize logger, and build with Gradle 8
+
 ## [v1.3.9] - 2022-01-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ AdapterLogger.LogError("Error message");
 * [Apache Maven](https://maven.apache.org/install.html)
 * [Gradle](https://gradle.org/install/)
 
-We currently build with JDK 1.8, Gradle 8.
-
 ### Building
 
 To build a new version of the CMA Java client library:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ For documenation on how to utilize this package in a Cumulus Deployment, please 
 
 ## Logging
 
-The message adapter library contains a logging class `AdapterLogger` that standardizes the log format for Cumulus. Static functions are provided to log error, fatal, warning, debug, info, and trace.
+The message adapter library contains a logging class `AdapterLogger` that standardizes the log format for Cumulus. Static functions are provided to log error, fatal, warning, debug, info, and trace. If AdapterLogger is used before calling 'RunCumulusTask', initialze it first. Please refer to the example
+[task](./task/src/main/java/test_task/task/Task.java).
 
 For example, to log an error, call:
 
@@ -88,6 +89,9 @@ AdapterLogger.LogError("Error message");
 ### Prerequisites
 
 * [Apache Maven](https://maven.apache.org/install.html)
+* [Gradle](https://gradle.org/install/)
+
+We currently build with JDK 1.8, Gradle 8.
 
 ### Building
 
@@ -105,7 +109,7 @@ These instructions assume that your task is using Maven for dependency managemen
 1. Get the current version number of the CMA Java client library from [`message_parser/pom.xml`](./message_parser/pom.xml):
 
     ```xml
-    <version>1.2.12</version>
+    <version>1.3.10</version>
     ```
 
 2. Make sure the `pom.xml` for your task includes a `dependency` referencing the correct version:
@@ -114,7 +118,7 @@ These instructions assume that your task is using Maven for dependency managemen
     <dependency>
       <groupId>gov.nasa.earthdata</groupId>
       <artifactId>cumulus-message-adapter</artifactId>
-      <version>1.2.12</version>
+      <version>1.3.10</version>
     </dependency>
     ```
 
@@ -122,13 +126,14 @@ These instructions assume that your task is using Maven for dependency managemen
 
     ```shell
     mvn install:install-file \
-      -Dfile=/path/to/cumulus-message-adapter-java/message_parser/target/cumulus-message-adapter-1.2.12.jar \
+      -Dfile=/path/to/cumulus-message-adapter-java/message_parser/target/cumulus-message-adapter-1.3.10.jar \
       -DgroupId=gov.nasa.earthdata \
       -DartifactId=cumulus-message-adapter \
-      -Dversion=1.2.12 \
+      -Dversion=1.3.10 \
       -Dpackaging=jar \
       -DgeneratePom=true
     mvn clean dependency:copy-dependencies
+    gradle build
     ```
 
 Running your task code (locally or when packaged and deployed) should now use the locally built CMA Java client package.

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.9</version>
+  <version>1.3.10</version>
   <name>cumulus-message-adapter</name>
   <url>https://github.com/cumulus-nasa/cumulus-message-adapter-java</url>
   <licenses>

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/AdapterLogger.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/AdapterLogger.java
@@ -217,7 +217,7 @@ public class AdapterLogger {
      * @param context - AWS Lambda context
      * @param event   - the original event passed into Lambda
      */
-    static void InitializeLogger(Context context, String event) {
+    public static void InitializeLogger(Context context, String event) {
         // Initialize log parameters from event
         SetAsyncOperationId(event);
         SetExecutions(event);

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/AdapterUtilities.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/AdapterUtilities.java
@@ -55,13 +55,6 @@ public class AdapterUtilities {
     private static String getJsonResponse(String url) throws IOException {
         URL requestUrl = new URL(url);
         HttpURLConnection conn = (HttpURLConnection) requestUrl.openConnection();
-        conn.setRequestProperty("Accept", "application/json");
-        conn.setRequestProperty("User-Agent", "@cumulus/deployment");
-
-        if (System.getenv("GITHUB_TOKEN") != null) {
-            conn.setRequestProperty("Authorization", "Bearer " + System.getenv("GITHUB_TOKEN"));
-        }
-
         if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
             throw new RuntimeException("Request Failed. HTTP Error Code: " + conn.getResponseCode());
         }

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/AdapterUtilities.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/AdapterUtilities.java
@@ -59,7 +59,7 @@ public class AdapterUtilities {
         conn.setRequestProperty("User-Agent", "@cumulus/deployment");
 
         if (System.getenv("GITHUB_TOKEN") != null) {
-            conn.setRequestProperty("Authorization", "token " + System.getenv("GITHUB_TOKEN"));
+            conn.setRequestProperty("Authorization", "Bearer " + System.getenv("GITHUB_TOKEN"));
         }
 
         if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {

--- a/task/README.md
+++ b/task/README.md
@@ -6,7 +6,7 @@ The business logic for the task is in `TaskLogic.java`. If an SNS topic arn is p
 
 ## Lambda Configuration
 
-The handler should be set to `test_task.task.Task::handleRequest`.
+The handler should be set to `test_task.task.Task::handleRequest` or `test_task.task.Task::handleRequestStreams`.
 
 ## SNS Configuration
 

--- a/task/build.gradle
+++ b/task/build.gradle
@@ -1,19 +1,24 @@
 apply plugin: 'java'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile fileTree(dir: 'target/lib', include: ['*.jar'])
+    implementation fileTree(dir: 'target/dependency', include: '*.jar')
+    implementation files("${System.properties['java.home']}/../lib/tools.jar")
 }
+
 
 task buildZip(type: Zip) {
     from compileJava
     from processResources              
     into('lib') {
-        from configurations.runtime
-    }           
+        from configurations.runtimeClasspath
+    }
+    archiveFileName = 'testTask.zip'
 }
 
 build.dependsOn buildZip

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -23,17 +23,17 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sns</artifactId>
-      <version>1.12.1</version>
+      <version>1.12.522</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.1</version>
+      <version>1.12.522</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/gov.nasa.earthdata/cumulus-message-adapter -->
     <dependency>

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -39,12 +39,17 @@
     <dependency>
       <groupId>gov.nasa.earthdata</groupId>
       <artifactId>cumulus-message-adapter</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.10</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.9</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
     </dependency>
   </dependencies>
   <build>

--- a/task/src/main/java/test_task/task/Task.java
+++ b/task/src/main/java/test_task/task/Task.java
@@ -3,15 +3,25 @@ package test_task.task;
 import com.amazonaws.services.lambda.runtime.Context; 
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 
+import cumulus_message_adapter.message_parser.AdapterLogger;
 import cumulus_message_adapter.message_parser.MessageParser;
 import cumulus_message_adapter.message_parser.MessageAdapterException;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 /**
  * Lambda request handler for testing Message Parser
  *
  */
-public class Task implements RequestHandler<String, String> 
+public class Task implements RequestHandler<String, String>
 {
+    String className = this.getClass().getName();
+
     /**
      * Handle request coming from Lambda. Call Message Parser.
      * @param input - String input from lambda
@@ -23,11 +33,27 @@ public class Task implements RequestHandler<String, String>
 
         try
         {
+            // If AdapterLogger is used before calling 'RunCumulusTask', initialze it first
+            AdapterLogger.InitializeLogger(context, input);
+            AdapterLogger.LogDebug(this.className + " handleRequest Input: " + input);
             return parser.RunCumulusTask(input, context, new TaskLogic());
         }
         catch(MessageAdapterException e)
         {
+            AdapterLogger.LogError(this.className + " handleRequest Error: " + e.getMessage());
             return e.getMessage();
         }
+    }
+
+    public void handleRequestStreams(InputStream inputStream, OutputStream outputStream, Context context) throws IOException, MessageAdapterException {
+        MessageParser parser = new MessageParser();
+
+        String input = IOUtils.toString(inputStream, "UTF-8");
+        // If AdapterLogger is used before calling 'RunCumulusTask', initialze it first
+        AdapterLogger.InitializeLogger(context, input);
+        AdapterLogger.LogDebug(this.className + " Input: " + input);
+        String output = parser.RunCumulusTask(input, context, new TaskLogic());
+        AdapterLogger.LogDebug(this.className + " Output: " + output);
+        outputStream.write(output.getBytes(Charset.forName("UTF-8")));
     }
 }

--- a/task/src/main/java/test_task/task/Task.java
+++ b/task/src/main/java/test_task/task/Task.java
@@ -33,7 +33,7 @@ public class Task implements RequestHandler<String, String>
 
         try
         {
-            // If AdapterLogger is used before calling 'RunCumulusTask', initialze it first
+            // If AdapterLogger is used before calling 'RunCumulusTask', initialize it first
             AdapterLogger.InitializeLogger(context, input);
             AdapterLogger.LogDebug(this.className + " handleRequest Input: " + input);
             return parser.RunCumulusTask(input, context, new TaskLogic());
@@ -49,7 +49,7 @@ public class Task implements RequestHandler<String, String>
         MessageParser parser = new MessageParser();
 
         String input = IOUtils.toString(inputStream, "UTF-8");
-        // If AdapterLogger is used before calling 'RunCumulusTask', initialze it first
+        // If AdapterLogger is used before calling 'RunCumulusTask', initialize it first
         AdapterLogger.InitializeLogger(context, input);
         AdapterLogger.LogDebug(this.className + " Input: " + input);
         String output = parser.RunCumulusTask(input, context, new TaskLogic());


### PR DESCRIPTION
- This PR/release works with cumulus-message-adapter v2.0.2. The latest cumulus-message-adapter v2.0.3 supports python 3.10.
But CMA-java circle build uses  cumuluss/openjdk:8-py37.  We build ci with MESSAGE_ADAPTER_VERSION env set to v2.0.2 to avoid using the latest cumulus-message-adapter.
- Will write a ticket for PODAAC after the release