### PR TITLE
CUMULUS-3386: use packaged cma

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       # run tests!
       - run: mvn -f message_parser/pom.xml integration-test
   
-  build_jdk8:
+  build:
     <<: *container_jdk8
     environment:
       # Customize the JVM maximum heap limit
@@ -107,4 +107,4 @@ workflows:
             - cumulus-packages
   build_test_jdk8:
     jobs:
-      - build_jdk8
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
   
   container_jdk11: &container_jdk11
     docker:
-      - image: cimg/openjdk:11.0.10
+      - image: cimg/openjdk:11.0.20
     working_directory: ~/message_parser
 
   # Download and cache dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,44 +4,61 @@
 #
 version: 2
 references:
-  container_jdk8: &container_jdk8
+  container_jdk8py37: &container_jdk8py37
     docker:
       - image: cumuluss/openjdk:8-py37
     working_directory: ~/message_parser
   
-  container_jdk11: &container_jdk11
+  container_jdk8: &container_jdk8
     docker:
-      - image: cimg/openjdk:11.0.20
+      - image: cimg/openjdk:8.0.362
     working_directory: ~/message_parser
 
   # Download and cache dependencies
+  restore_cache_jdk8py37: &restore_cache_jdk8py37
+    restore_cache:
+      keys:
+        - jdk8py37-dependencies-{{ checksum "message_parser/pom.xml" }}
+        # fallback to using the latest cache if no exact match is found
+        - jdk8py37-dependencies-
+  
   restore_cache_jdk8: &restore_cache_jdk8
     restore_cache:
       keys:
         - jdk8-dependencies-{{ checksum "message_parser/pom.xml" }}
         # fallback to using the latest cache if no exact match is found
         - jdk8-dependencies-
-  
-  restore_cache_jdk11: &restore_cache_jdk11
-    restore_cache:
-      keys:
-        - jdk11-dependencies-{{ checksum "message_parser/pom.xml" }}
-        # fallback to using the latest cache if no exact match is found
-        - jdk11-dependencies-
 
+  save_cache_jdk8py37: &save_cache_jdk8py37
+    save_cache:
+      paths:
+        - ~/jdk8py37
+      key: jdk8py37-dependencies-{{ checksum "message_parser/pom.xml" }}
+  
   save_cache_jdk8: &save_cache_jdk8
     save_cache:
       paths:
         - ~/jdk8
       key: jdk8-dependencies-{{ checksum "message_parser/pom.xml" }}
-  
-  save_cache_jdk11: &save_cache_jdk11
-    save_cache:
-      paths:
-        - ~/jdk11
-      key: jdk11-dependencies-{{ checksum "message_parser/pom.xml" }}
 
 jobs:
+  build_jdk8py37:
+    <<: *container_jdk8py37
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+      - *restore_cache_jdk8py37
+
+      - run: mvn -f message_parser/pom.xml dependency:go-offline
+
+      - *save_cache_jdk8py37
+
+      # run tests!
+      - run: mvn -f message_parser/pom.xml integration-test
+  
   build_jdk8:
     <<: *container_jdk8
     environment:
@@ -58,26 +75,9 @@ jobs:
 
       # run tests!
       - run: mvn -f message_parser/pom.xml integration-test
-  
-  build_jdk11:
-    <<: *container_jdk11
-    environment:
-      # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3200m
-
-    steps:
-      - checkout
-      - *restore_cache_jdk11
-
-      - run: mvn -f message_parser/pom.xml dependency:go-offline
-
-      - *save_cache_jdk11
-
-      # run tests!
-      - run: mvn -f message_parser/pom.xml integration-test
 
   deploy:
-    <<: *container_jdk8
+    <<: *container_jdk8py37
 
     steps:
       - checkout
@@ -94,17 +94,17 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build_jdk8:
+      - build_jdk8py37:
           context:
             - cumulus-packages
       - deploy:
           requires:
-            - build_jdk8
+            - build_jdk8py37
           filters:
             branches:
               only: master
           context:
             - cumulus-packages
-  build_test_jdk11:
+  build_test_jdk8:
     jobs:
-      - build_jdk11
+      - build_jdk8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,49 +3,81 @@
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
 version: 2
-jobs:
-  build:
+references:
+  container_jdk8: &container_jdk8
     docker:
-      # specify the version you desire here
       - image: cumuluss/openjdk:8-py37
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
+    working_directory: ~/message_parser
+  
+  container_jdk11: &container_jdk11
+    docker:
+      - image: cimg/openjdk:11.0.10
     working_directory: ~/message_parser
 
+  # Download and cache dependencies
+  restore_cache_jdk8: &restore_cache_jdk8
+    restore_cache:
+      keys:
+        - jdk8-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        # fallback to using the latest cache if no exact match is found
+        - jdk8-dependencies-
+  
+  restore_cache_jdk11: &restore_cache_jdk11
+    restore_cache:
+      keys:
+        - jdk11-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        # fallback to using the latest cache if no exact match is found
+        - jdk11-dependencies-
+
+  save_cache_jdk8: &save_cache_jdk8
+    save_cache:
+      paths:
+        - ~/jdk8
+      key: jdk8-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+  
+  save_cache_jdk11: &save_cache_jdk11
+    save_cache:
+      paths:
+        - ~/jdk11
+      key: jdk11-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+
+jobs:
+  build_jdk8:
+    <<: *container_jdk8
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
 
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "message_parser/pom.xml" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      - *restore_cache_jdk8
 
       - run: mvn -f message_parser/pom.xml dependency:go-offline
 
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies-{{ checksum "message_parser/pom.xml" }}
+      - *save_cache_jdk8
+
+      # run tests!
+      - run: mvn -f message_parser/pom.xml integration-test
+  
+  build_jdk11:
+    <<: *container_jdk11
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+      - *restore_cache_jdk11
+
+      - run: mvn -f message_parser/pom.xml dependency:go-offline
+
+      - *save_cache_jdk11
 
       # run tests!
       - run: mvn -f message_parser/pom.xml integration-test
 
   deploy:
-    docker:
-      # specify the version you desire here
-      - image: cumuluss/openjdk:8-py37
-
-    working_directory: ~/message_parser
+    <<: *container_jdk8
 
     steps:
       - checkout
@@ -62,14 +94,17 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build:
+      - build_jdk8:
           context:
             - cumulus-packages
       - deploy:
           requires:
-            - build
+            - build_jdk8
           filters:
             branches:
               only: master
           context:
             - cumulus-packages
+  build_test_jdk11:
+    jobs:
+      - build_jdk11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,14 @@ references:
   restore_cache_jdk8: &restore_cache_jdk8
     restore_cache:
       keys:
-        - jdk8-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        - jdk8-dependencies-{{ checksum "message_parser/pom.xml" }}
         # fallback to using the latest cache if no exact match is found
         - jdk8-dependencies-
   
   restore_cache_jdk11: &restore_cache_jdk11
     restore_cache:
       keys:
-        - jdk11-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        - jdk11-dependencies-{{ checksum "message_parser/pom.xml" }}
         # fallback to using the latest cache if no exact match is found
         - jdk11-dependencies-
 
@@ -33,13 +33,13 @@ references:
     save_cache:
       paths:
         - ~/jdk8
-      key: jdk8-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+      key: jdk8-dependencies-{{ checksum "message_parser/pom.xml" }}
   
   save_cache_jdk11: &save_cache_jdk11
     save_cache:
       paths:
         - ~/jdk11
-      key: jdk11-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+      key: jdk11-dependencies-{{ checksum "message_parser/pom.xml" }}
 
 jobs:
   build_jdk8:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 This version of the CMA java client works with cumulus-message-adapter
 [v2.0.2](https://github.com/nasa/cumulus-message-adapter/releases/tag/v2.0.2) or later,
-and it's built with JDK 1.8.  The package works on AWS Runtime Java 8 environment, for both Amazon Linux 1 and 2.
+and it's built with JDK 1.8.  When use the java client package in AWS Runtime environment,
+for Java 8 Amazon Linux 1, use cumulus-message-adapter v2.0.2,
+and for Java 8 Amazon Linux 2, use cumulus-message-adapter v2.0.3 or later.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Note
+
+This version of the CMA java client works with cumulus-message-adapter
+[v2.0.2](https://github.com/nasa/cumulus-message-adapter/releases/tag/v2.0.2) or later,
+and it's built with JDK 1.8.
+
+### Changed
+
+- **CUMULUS-3386**
+  - Updated CMA client to utilize pre-packaged AWS LINUX 2 binary for CMA when system python is unavailable or
+  USE_CMA_BINARY environment is set to true. This is a breaking change if your task environment does not have
+  python in the system path, but generally should be backward compatible with most use cases.
+
 ## [v1.3.10] - 2023-08-07
 
 ### Note

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and it's built with JDK 1.8.
   - Updated CMA client to utilize pre-packaged AWS LINUX 2 binary for CMA when system python is unavailable or
   USE_CMA_BINARY environment is set to true. This is a breaking change if your task environment does not have
   python in the system path, but generally should be backward compatible with most use cases.
+  - Updated ci configuration to test the package in both jdk8(with py37) and jdk11(no python) environments
 
 ## [v1.3.10] - 2023-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
-### Note
+## [v1.4.0] - 2023-08-17
+
+### Notable Changes
 
 This version of the CMA java client works with cumulus-message-adapter
 [v2.0.2](https://github.com/nasa/cumulus-message-adapter/releases/tag/v2.0.2) or later,
-and it's built with JDK 1.8.
+and it's built with JDK 1.8.  The package works on AWS Runtime Java 8 environment, for both Amazon Linux 1 and 2.
 
 ### Changed
 
@@ -18,11 +20,11 @@ and it's built with JDK 1.8.
   - Updated CMA client to utilize pre-packaged AWS LINUX 2 binary for CMA when system python is unavailable or
   USE_CMA_BINARY environment is set to true. This is a breaking change if your task environment does not have
   python in the system path, but generally should be backward compatible with most use cases.
-  - Updated ci configuration to test the package in both jdk8(with py37) and jdk11(no python) environments
+  - Updated ci configuration to test the package on jdk8 environment both with and without system python
 
 ## [v1.3.10] - 2023-08-07
 
-### Note
+### Notable Changes
 
 This version of the CMA java client works with cumulus-message-adapter
 [v2.0.2](https://github.com/nasa/cumulus-message-adapter/releases/tag/v2.0.2) or earlier,

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -36,6 +36,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <version>1.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-core</artifactId>
       <version>1.2.0</version>

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -76,6 +76,10 @@
       <configuration>
         <source>1.8</source>
         <target>1.8</target>
+        <compilerArgs>
+          <arg>-Xlint:deprecation</arg>
+          <arg>-Xlint:unchecked</arg>
+        </compilerArgs>
       </configuration>
     </plugin>
     <plugin>

--- a/message_parser/pom.xml
+++ b/message_parser/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.10</version>
+  <version>1.4.0</version>
   <name>cumulus-message-adapter</name>
   <url>https://github.com/cumulus-nasa/cumulus-message-adapter-java</url>
   <licenses>

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
@@ -41,12 +41,11 @@ public class MessageAdapter implements IMessageAdapter
         boolean pythonExistsInPath = Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator)))
                 .map(Paths::get)
                 .anyMatch(path -> Files.exists(path.resolve(systemPython)));
-        // TODO figure out how to set USE_CMA_BINARY env in test
-        pythonExistsInPath = false;
+
         if (pythonExistsInPath && System.getenv("USE_CMA_BINARY") != "true") {
           return new ProcessBuilder(systemPython, messageAdapterPath, command);
         }
-        // If there is no system python, attempt use of pre-packaged CMA binary
+        // If there is no system python or USE_CMA_BINARY is true, attempt use of pre-packaged CMA binary
         return new ProcessBuilder(messageAdapterPath + "/cma_bin/cma", command);
       }
 

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
@@ -32,7 +32,7 @@ public class MessageAdapter implements IMessageAdapter
 
     private ProcessBuilder buildProcess(String command)
     {
-        String messageAdapterPath = "cumulus-message-adapter";
+        String messageAdapterPath = System.getProperty("user.dir") + File.separator + "cumulus-message-adapter";
         String messageAdapterDir = GetMessageAdapterEnvironmentVariable();
         if(messageAdapterDir != null) {
             messageAdapterPath = messageAdapterDir;
@@ -60,10 +60,12 @@ public class MessageAdapter implements IMessageAdapter
         throws MessageAdapterException
     {
         String messageAdapterOutput = "";
+        String command = "";
 
         try
         {
             ProcessBuilder processBuilder = buildProcess(messageAdapterFunction);
+            command = processBuilder.command().toString();
             Process process = processBuilder.start();
 
             OutputStreamWriter writer = new OutputStreamWriter(process.getOutputStream());
@@ -120,8 +122,9 @@ public class MessageAdapter implements IMessageAdapter
         }
         catch(IOException e)
         {
-            AdapterLogger.LogError("Unable to find Cumulus Message Adapter: " + e.getMessage());
-            throw new MessageAdapterException("Unable to find Cumulus Message Adapter", e.getCause());
+            String errorString = String.format("Unable to find Cumulus Message Adapter: %s: %s", command, e.getMessage());
+            AdapterLogger.LogError(errorString);
+            throw new MessageAdapterException(errorString);
         }
 
         return messageAdapterOutput;

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageAdapter.java
@@ -24,6 +24,7 @@ import com.google.gson.GsonBuilder;
 public class MessageAdapter implements IMessageAdapter
 {
     private static final int MESSAGE_ADAPTER_TIMEOUT = 60 * 5; // seconds
+    private static final String systemPython = "python3";
 
     public String GetMessageAdapterEnvironmentVariable()
     {
@@ -37,7 +38,7 @@ public class MessageAdapter implements IMessageAdapter
         if(messageAdapterDir != null) {
             messageAdapterPath = messageAdapterDir;
         }
-        String systemPython = "python3";
+
         boolean pythonExistsInPath = Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator)))
                 .map(Paths::get)
                 .anyMatch(path -> Files.exists(path.resolve(systemPython)));

--- a/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageParser.java
+++ b/message_parser/src/main/java/cumulus_message_adapter/message_parser/MessageParser.java
@@ -90,8 +90,7 @@ public class MessageParser implements IMessageParser
             if(e.getClass().getSimpleName().contains("WorkflowError") ||
                e.getClass().getSimpleName().contains("WorkflowException"))
             {
-                JsonElement jelement = new JsonParser().parse(input);
-                JsonObject inputObject = jelement.getAsJsonObject();
+                JsonObject inputObject = JsonParser.parseString(input).getAsJsonObject();
                 inputObject.add("payload", null);
                 inputObject.addProperty("exception", e.getMessage());
                 return inputObject.toString();

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageAdapterEnvironmentTest.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageAdapterEnvironmentTest.java
@@ -56,7 +56,7 @@ public class MessageAdapterEnvironmentTest
      * Test message handler works correctly when an alternate path is specified
      */
     @Test
-    public void testMessageAdapterAlternate() {
+    public void testMessageAdapterAlternate() throws Exception {
         withEnvironmentVariable("CUMULUS_MESSAGE_ADAPTER_DIR", "alternate-cumulus-message-adapter")
                 .execute(() -> testAndVerifyMessageParser());
     }

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageAdapterEnvironmentTest.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageAdapterEnvironmentTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import static org.junit.Assert.*;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.*;
 
 import java.io.IOException;
 import java.util.Map;
@@ -29,19 +30,11 @@ public class MessageAdapterEnvironmentTest
 
     /*
      * Test that the message handler is hitting all of the correct functions and converting the params
-     * to JSON correctly if an alternate path is specified
+     * to JSON correctly
      */
-    @Test
-    public void testMessageAdapterAlternate()
+    void testAndVerifyMessageParser()
     {
-        class MessageAdapterMock extends MessageAdapter {
-            public String GetMessageAdapterEnvironmentVariable()
-            {
-                return "alternate-cumulus-message-adapter";
-            }
-        }
-
-        MessageParser parser = new MessageParser(new MessageAdapterMock());
+        MessageParser parser = new MessageParser(new MessageAdapter());
         try
         {
             String inputJsonString = AdapterUtilities.loadResourceToString("basic.input.json");
@@ -57,5 +50,23 @@ public class MessageAdapterEnvironmentTest
             e.printStackTrace();
             fail();
         }
+    }
+
+    /*
+     * Test message handler works correctly when an alternate path is specified
+     */
+    @Test
+    public void testMessageAdapterAlternate() {
+        withEnvironmentVariable("CUMULUS_MESSAGE_ADAPTER_DIR", "alternate-cumulus-message-adapter")
+                .execute(() -> testAndVerifyMessageParser());
+    }
+
+    /*
+     * Test message handler works correctly when packaged CMA is executed
+     */
+    @Test
+    public void testPackagedCma() throws Exception {
+        withEnvironmentVariable("USE_CMA_BINARY", "true")
+                .execute(() -> testAndVerifyMessageParser());
     }
 }

--- a/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageAdapterEnvironmentTest.java
+++ b/message_parser/src/test/java/cumulus_message_adapter/message_parser/MessageAdapterEnvironmentTest.java
@@ -9,6 +9,7 @@ import org.junit.AfterClass;
 import static org.junit.Assert.*;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
@@ -19,12 +20,14 @@ public class MessageAdapterEnvironmentTest
     {
         AdapterUtilities.deleteCMA("alternate-cumulus-message-adapter");
         AdapterUtilities.deleteCMA("cumulus-message-adapter");
+        AdapterUtilities.downloadCMA("cumulus-message-adapter");
         AdapterUtilities.downloadCMA("alternate-cumulus-message-adapter");
     }
 
     @AfterClass
     public static void teardown() throws IOException
     {
+        AdapterUtilities.deleteCMA("cumulus-message-adapter");
         AdapterUtilities.deleteCMA("alternate-cumulus-message-adapter");
     }
 
@@ -57,7 +60,9 @@ public class MessageAdapterEnvironmentTest
      */
     @Test
     public void testMessageAdapterAlternate() throws Exception {
-        withEnvironmentVariable("CUMULUS_MESSAGE_ADAPTER_DIR", "alternate-cumulus-message-adapter")
+        String currentDirectory = System.getProperty("user.dir");
+        String alternativeDirectory = currentDirectory + File.separator + "alternate-cumulus-message-adapter";
+        withEnvironmentVariable("CUMULUS_MESSAGE_ADAPTER_DIR", alternativeDirectory)
                 .execute(() -> testAndVerifyMessageParser());
     }
 
@@ -67,6 +72,18 @@ public class MessageAdapterEnvironmentTest
     @Test
     public void testPackagedCma() throws Exception {
         withEnvironmentVariable("USE_CMA_BINARY", "true")
+                .execute(() -> testAndVerifyMessageParser());
+    }
+
+    /*
+     * Test message handler works correctly when an alternate CMA path is specified and packaged CMA is executed
+     */
+    @Test
+    public void testAlternativeCmaPathAndPackagedCma() throws Exception {
+        String currentDirectory = System.getProperty("user.dir");
+        String alternativeDirectory = currentDirectory + File.separator + "alternate-cumulus-message-adapter";
+        withEnvironmentVariable("CUMULUS_MESSAGE_ADAPTER_DIR", alternativeDirectory)
+                .and("USE_CMA_BINARY", "true")
                 .execute(() -> testAndVerifyMessageParser());
     }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@ export VERSION_TAG="v$VERSION_NUMBER"
 
 LATEST_TAG=$(curl -H \
   "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/nasa/cumulus-message-adapter-java/tags | jq --raw-output '.[0].name')
+  https://api.github.com/repos/nasa/cumulus-message-adapter-java/tags | jq --raw-output '[.[]|.name]|.[0]')
 export LATEST_TAG
 
 if [ "$VERSION_TAG" != "$LATEST_TAG" ]; then

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>gov.nasa.earthdata</groupId>
       <artifactId>cumulus-message-adapter</artifactId>
-      <version>1.3.10</version>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
The new generated package (build with jdk1.8) works on java 8 Amazon Linux 1 and 2 now, but doesn't work on jdk 11 due to log4j error.
I will work on java 11 release on a separate PR.

log4j errors when running package (built with jdk1.8) in java 11:
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
Caused by: java.lang.UnsupportedOperationException: No class provided, and an appropriate one cannot be found.
	at org.apache.logging.log4j.LogManager.callerClass(LogManager.java:573)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:598)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:585)
	at cumulus_message_adapter.message_parser.AdapterLogger.<clinit>(AdapterLogger.java:21)